### PR TITLE
Make episodes section more generic

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,10 +21,9 @@
                     <div class="episode-placeholder">Episode 1</div>
                 </div>
                 <div class="episode-content">
-                    <h3>Criteria</h3>
-                    <p>Exploring the concrete significance of number as our foundational explanatory principles in order to establish criteria for a meaningful cosmology.</p>
+                    <h3>Episode 1</h3>
+                    <p>Coming soon.</p>
                     <div class="episode-meta">
-                        <span class="episode-number">Episode 1</span>
                         <span class="episode-date">Coming Soon</span>
                     </div>
                 </div>
@@ -35,10 +34,9 @@
                     <div class="episode-placeholder">Episode 2</div>
                 </div>
                 <div class="episode-content">
-                    <h3>Digital Consciousness</h3>
-                    <p>How technology mirrors natural patterns and what this reveals about consciousness itself.</p>
+                    <h3>Episode 2</h3>
+                    <p>Coming soon.</p>
                     <div class="episode-meta">
-                        <span class="episode-number">Episode 2</span>
                         <span class="episode-date">Coming Soon</span>
                     </div>
                 </div>
@@ -49,10 +47,9 @@
                     <div class="episode-placeholder">Episode 3</div>
                 </div>
                 <div class="episode-content">
-                    <h3>Ecological Networks</h3>
-                    <p>Understanding how natural ecosystems inform sustainable digital architecture.</p>
+                    <h3>Episode 3</h3>
+                    <p>Coming soon.</p>
                     <div class="episode-meta">
-                        <span class="episode-number">Episode 3</span>
                         <span class="episode-date">Coming Soon</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Replaced opinionated episode content with generic placeholders
- Simplified episode titles to "Episode 1", "Episode 2", etc.
- Made descriptions generic ("Coming soon") to allow for future content planning

## Test plan
- [x] Preview the homepage to ensure episodes section displays correctly
- [x] Verify layout and styling remain intact
- [x] Confirm placeholder content is appropriately generic

🤖 Generated with [Claude Code](https://claude.ai/code)