### PR TITLE
Add clickable pentads to eight cosmoses pages

### DIFF
--- a/content/eight-cosmoses/_index.md
+++ b/content/eight-cosmoses/_index.md
@@ -1,0 +1,5 @@
++++
+title = "The Eight Reciprocal Cosmoses"
+template = "meta.html"
+sort_by = "weight"
++++

--- a/content/eight-cosmoses/animoid-cosmos.md
+++ b/content/eight-cosmoses/animoid-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Animoid Cosmos"
+template = "meta-page.html"
+weight = 4
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #7a2d8f; margin-bottom: 0.5rem;">IDIOSYNCRASY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#BA55D3" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#BA55D3" fill-opacity="0.2" stroke="#BA55D3" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#7a2d8f">E6</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#7a2d8f">Organismic</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#BA55D3" fill-opacity="0.2" stroke="#BA55D3" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#7a2d8f">E5</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#7a2d8f">Sensitive</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#BA55D3" fill-opacity="0.2" stroke="#BA55D3" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#7a2d8f">E7</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#7a2d8f">Regenerative</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#BA55D3" fill-opacity="0.2" stroke="#BA55D3" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#7a2d8f">E4</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#7a2d8f">Conscious</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#BA55D3" fill-opacity="0.2" stroke="#BA55D3" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#7a2d8f">E8</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#7a2d8f">Constructive</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/crystalline-cosmos.md
+++ b/content/eight-cosmoses/crystalline-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Crystalline Cosmos"
+template = "meta-page.html"
+weight = 8
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #b56200; margin-bottom: 0.5rem;">MATERIALITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#FF8C00" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#FF8C00" fill-opacity="0.2" stroke="#FF8C00" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b56200">E10</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b56200">Cohesive</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#FF8C00" fill-opacity="0.2" stroke="#FF8C00" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b56200">E9</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b56200">Adaptive</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#FF8C00" fill-opacity="0.2" stroke="#FF8C00" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b56200">E11</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b56200">Patterning</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#FF8C00" fill-opacity="0.2" stroke="#FF8C00" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b56200">E8</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b56200">Constructive</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#FF8C00" fill-opacity="0.2" stroke="#FF8C00" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b56200">E12</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b56200">Zero Point</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/generative-cosmos.md
+++ b/content/eight-cosmoses/generative-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Generative Cosmos"
+template = "meta-page.html"
+weight = 2
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #1a3a8a; margin-bottom: 0.5rem;">INDIVIDUALITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#4169E1" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#4169E1" fill-opacity="0.2" stroke="#4169E1" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a3a8a">E4</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a3a8a">Conscious</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#4169E1" fill-opacity="0.2" stroke="#4169E1" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a3a8a">E3</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a3a8a">Creative</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#4169E1" fill-opacity="0.2" stroke="#4169E1" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a3a8a">E5</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a3a8a">Sensitive</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#4169E1" fill-opacity="0.2" stroke="#4169E1" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a3a8a">E2</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a3a8a">Unitive</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#4169E1" fill-opacity="0.2" stroke="#4169E1" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a3a8a">E6</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a3a8a">Organismic</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/germinal-cosmos.md
+++ b/content/eight-cosmoses/germinal-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Germinal Cosmos"
+template = "meta-page.html"
+weight = 5
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #5b3d9e; margin-bottom: 0.5rem;">FERTILITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#9370DB" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#9370DB" fill-opacity="0.2" stroke="#9370DB" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#5b3d9e">E7</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#5b3d9e">Regenerative</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#9370DB" fill-opacity="0.2" stroke="#9370DB" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#5b3d9e">E6</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#5b3d9e">Organismic</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#9370DB" fill-opacity="0.2" stroke="#9370DB" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#5b3d9e">E8</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#5b3d9e">Constructive</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#9370DB" fill-opacity="0.2" stroke="#9370DB" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#5b3d9e">E5</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#5b3d9e">Sensitive</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#9370DB" fill-opacity="0.2" stroke="#9370DB" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#5b3d9e">E9</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#5b3d9e">Adaptive</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/humanoid-cosmos.md
+++ b/content/eight-cosmoses/humanoid-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Humanoid Cosmos"
+template = "meta-page.html"
+weight = 3
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #8b0a25; margin-bottom: 0.5rem;">PERCEPTIVITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#DC143C" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#DC143C" fill-opacity="0.2" stroke="#DC143C" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#8b0a25">E5</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#8b0a25">Sensitive</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#DC143C" fill-opacity="0.2" stroke="#DC143C" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#8b0a25">E4</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#8b0a25">Conscious</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#DC143C" fill-opacity="0.2" stroke="#DC143C" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#8b0a25">E6</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#8b0a25">Organismic</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#DC143C" fill-opacity="0.2" stroke="#DC143C" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#8b0a25">E3</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#8b0a25">Creative</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#DC143C" fill-opacity="0.2" stroke="#DC143C" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#8b0a25">E7</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#8b0a25">Regenerative</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/phytogenic-cosmos.md
+++ b/content/eight-cosmoses/phytogenic-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Phytogenic Cosmos"
+template = "meta-page.html"
+weight = 6
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #1a7a1a; margin-bottom: 0.5rem;">VITALITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#32CD32" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#32CD32" fill-opacity="0.2" stroke="#32CD32" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a7a1a">E8</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a7a1a">Constructive</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#32CD32" fill-opacity="0.2" stroke="#32CD32" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a7a1a">E7</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a7a1a">Regenerative</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#32CD32" fill-opacity="0.2" stroke="#32CD32" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a7a1a">E9</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a7a1a">Adaptive</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#32CD32" fill-opacity="0.2" stroke="#32CD32" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a7a1a">E6</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a7a1a">Organismic</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#32CD32" fill-opacity="0.2" stroke="#32CD32" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#1a7a1a">E10</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#1a7a1a">Cohesive</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/sustaining-cosmos.md
+++ b/content/eight-cosmoses/sustaining-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Sustaining Cosmos"
+template = "meta-page.html"
+weight = 7
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #b5341f; margin-bottom: 0.5rem;">COMPLEXITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#FF6347" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#FF6347" fill-opacity="0.2" stroke="#FF6347" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b5341f">E9</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b5341f">Adaptive</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#FF6347" fill-opacity="0.2" stroke="#FF6347" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b5341f">E8</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b5341f">Constructive</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#FF6347" fill-opacity="0.2" stroke="#FF6347" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b5341f">E10</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b5341f">Cohesive</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#FF6347" fill-opacity="0.2" stroke="#FF6347" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b5341f">E7</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b5341f">Regenerative</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#FF6347" fill-opacity="0.2" stroke="#FF6347" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#b5341f">E11</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#b5341f">Patterning</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/eight-cosmoses/undivided-cosmos.md
+++ b/content/eight-cosmoses/undivided-cosmos.md
@@ -1,0 +1,53 @@
++++
+title = "The Undivided Cosmos"
+template = "meta-page.html"
+weight = 1
++++
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+<h3 style="text-align: center; font-family: Arial, sans-serif; color: #222; margin-bottom: 0.5rem;">UNITY</h3>
+
+<svg viewBox="0 0 530 500" xmlns="http://www.w3.org/2000/svg" style="max-width: 530px; width: 100%; display: block; margin: 0 auto;">
+  <!-- All 10 connecting lines (complete graph K5) -->
+  <line x1="80" y1="250" x2="240" y2="100" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="240" y2="400" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="60" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="80" y1="250" x2="430" y2="440" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="240" y2="400" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="60" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="100" x2="430" y2="440" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="60" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="240" y1="400" x2="430" y2="440" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <line x1="430" y1="60" x2="430" y2="440" stroke="#555" stroke-width="2" stroke-opacity="0.6"/>
+  <!-- Left node (central energy) -->
+  <circle cx="80" cy="250" r="36" fill="#555" fill-opacity="0.2" stroke="#555" stroke-width="2"/>
+  <text x="80" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#222">E3</text>
+  <text x="80" y="259" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#222">Creative</text>
+  <!-- Mid-top node -->
+  <circle cx="240" cy="100" r="36" fill="#555" fill-opacity="0.2" stroke="#555" stroke-width="2"/>
+  <text x="240" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#222">E2</text>
+  <text x="240" y="109" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#222">Unitive</text>
+  <!-- Mid-bottom node -->
+  <circle cx="240" cy="400" r="36" fill="#555" fill-opacity="0.2" stroke="#555" stroke-width="2"/>
+  <text x="240" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#222">E4</text>
+  <text x="240" y="409" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#222">Conscious</text>
+  <!-- Right-top node -->
+  <circle cx="430" cy="60" r="36" fill="#555" fill-opacity="0.2" stroke="#555" stroke-width="2"/>
+  <text x="430" y="55" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#222">E1</text>
+  <text x="430" y="69" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#222">Transcendent</text>
+  <!-- Right-bottom node -->
+  <circle cx="430" cy="440" r="36" fill="#555" fill-opacity="0.2" stroke="#555" stroke-width="2"/>
+  <text x="430" y="435" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#222">E5</text>
+  <text x="430" y="449" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#222">Sensitive</text>
+</svg>
+
+</div>
+
+<div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
+
+### Commentary
+
+[DU2 text to be added]
+
+</div>

--- a/content/meta/eight-cosmoses.md
+++ b/content/meta/eight-cosmoses.md
@@ -3,6 +3,13 @@ title = "The Eight Reciprocal Cosmoses"
 template = "meta-page.html"
 +++
 
+<style>
+  .cosmos-pentad { cursor: pointer; }
+  .cosmos-pentad:hover rect { fill-opacity: 0.12 !important; }
+  .cosmos-pentad:hover circle.hub { r: 10; }
+  .cosmos-pentad:hover line { stroke-width: 2; }
+</style>
+
 <div style="background-color: white; padding: 2rem; border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); margin-bottom: 2rem;">
 
 <div class="eight-cosmoses-content">
@@ -20,102 +27,159 @@ template = "meta-page.html"
 <line x1="30" y1="290" x2="670" y2="290" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="295" font-family="Arial, sans-serif" font-size="13">E2 Unitive Energy</text>
 <circle cx="190" cy="290" r="5" fill="#20357A"/>
+
+<!-- Undivided Cosmos (E3) -->
+<a href="/eight-cosmoses/undivided-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="320" width="400" height="40" fill="#000" fill-opacity="0"/>
 <line x1="30" y1="340" x2="670" y2="340" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="345" font-family="Arial, sans-serif" font-size="13">E3 Creative Energy</text>
-<circle cx="280" cy="340" r="8" fill="#000"/>
+<circle class="hub" cx="280" cy="340" r="8" fill="#000"/>
 <text x="320" y="345" font-family="Arial, sans-serif" font-size="13" font-weight="bold">UNITY</text>
-<text x="450" y="340" font-family="Arial, sans-serif" font-size="13">Undivided</text>
-<text x="450" y="355" font-family="Arial, sans-serif" font-size="13">Cosmos</text>
+<text x="450" y="340" font-family="Arial, sans-serif" font-size="13" text-decoration="underline">Undivided</text>
+<text x="450" y="355" font-family="Arial, sans-serif" font-size="13" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="340" r="5" fill="#52293E"/>
 <line x1="280" y1="340" x2="190" y2="240" stroke="#000" stroke-width="1"/>
 <line x1="280" y1="340" x2="190" y2="290" stroke="#000" stroke-width="1"/>
 <line x1="280" y1="340" x2="190" y2="340" stroke="#000" stroke-width="1"/>
 <line x1="280" y1="340" x2="190" y2="390" stroke="#000" stroke-width="1"/>
 <line x1="280" y1="340" x2="190" y2="440" stroke="#000" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Generative Cosmos (E4) -->
+<a href="/eight-cosmoses/generative-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="370" width="400" height="40" fill="#4169E1" fill-opacity="0"/>
 <line x1="30" y1="390" x2="670" y2="390" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="395" font-family="Arial, sans-serif" font-size="13">E4 Conscious Energy</text>
-<circle cx="280" cy="390" r="8" fill="#4169E1"/>
+<circle class="hub" cx="280" cy="390" r="8" fill="#4169E1"/>
 <text x="320" y="395" font-family="Arial, sans-serif" font-size="13" font-weight="bold">INDIVIDUALITY</text>
-<text x="450" y="390" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#4169E1">Generative</text>
-<text x="450" y="405" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#4169E1">Cosmos</text>
+<text x="450" y="390" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#4169E1" text-decoration="underline">Generative</text>
+<text x="450" y="405" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#4169E1" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="390" r="5" fill="#7F4485"/>
 <line x1="280" y1="390" x2="190" y2="290" stroke="#4169E1" stroke-width="1"/>
 <line x1="280" y1="390" x2="190" y2="340" stroke="#4169E1" stroke-width="1"/>
 <line x1="280" y1="390" x2="190" y2="390" stroke="#4169E1" stroke-width="1"/>
 <line x1="280" y1="390" x2="190" y2="440" stroke="#4169E1" stroke-width="1"/>
 <line x1="280" y1="390" x2="190" y2="490" stroke="#4169E1" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Humanoid Cosmos (E5) -->
+<a href="/eight-cosmoses/humanoid-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="420" width="400" height="40" fill="#DC143C" fill-opacity="0"/>
 <line x1="30" y1="440" x2="670" y2="440" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="445" font-family="Arial, sans-serif" font-size="13">E5 Sensitive Energy</text>
-<circle cx="280" cy="440" r="8" fill="#DC143C"/>
+<circle class="hub" cx="280" cy="440" r="8" fill="#DC143C"/>
 <text x="320" y="445" font-family="Arial, sans-serif" font-size="13" font-weight="bold">PERCEPTIVITY</text>
-<text x="450" y="440" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#DC143C">Humanoid</text>
-<text x="450" y="455" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#DC143C">Cosmos</text>
+<text x="450" y="440" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#DC143C" text-decoration="underline">Humanoid</text>
+<text x="450" y="455" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#DC143C" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="440" r="5" fill="#9F4184"/>
 <line x1="280" y1="440" x2="190" y2="340" stroke="#DC143C" stroke-width="1"/>
 <line x1="280" y1="440" x2="190" y2="390" stroke="#DC143C" stroke-width="1"/>
 <line x1="280" y1="440" x2="190" y2="440" stroke="#DC143C" stroke-width="1"/>
 <line x1="280" y1="440" x2="190" y2="490" stroke="#DC143C" stroke-width="1"/>
 <line x1="280" y1="440" x2="190" y2="540" stroke="#DC143C" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Animoid Cosmos (E6) -->
+<a href="/eight-cosmoses/animoid-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="470" width="400" height="40" fill="#BA55D3" fill-opacity="0"/>
 <line x1="30" y1="490" x2="670" y2="490" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="495" font-family="Arial, sans-serif" font-size="13">E6 Organismic Energy</text>
-<circle cx="280" cy="490" r="8" fill="#BA55D3"/>
+<circle class="hub" cx="280" cy="490" r="8" fill="#BA55D3"/>
 <text x="320" y="495" font-family="Arial, sans-serif" font-size="13" font-weight="bold">IDIOSYNCRASY</text>
-<text x="450" y="490" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#BA55D3">Animoid</text>
-<text x="450" y="505" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#BA55D3">Cosmos</text>
+<text x="450" y="490" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#BA55D3" text-decoration="underline">Animoid</text>
+<text x="450" y="505" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#BA55D3" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="490" r="5" fill="#825793"/>
 <line x1="280" y1="490" x2="190" y2="390" stroke="#BA55D3" stroke-width="1"/>
 <line x1="280" y1="490" x2="190" y2="440" stroke="#BA55D3" stroke-width="1"/>
 <line x1="280" y1="490" x2="190" y2="490" stroke="#BA55D3" stroke-width="1"/>
 <line x1="280" y1="490" x2="190" y2="540" stroke="#BA55D3" stroke-width="1"/>
 <line x1="280" y1="490" x2="190" y2="590" stroke="#BA55D3" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Germinal Cosmos (E7) -->
+<a href="/eight-cosmoses/germinal-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="520" width="400" height="40" fill="#9370DB" fill-opacity="0"/>
 <line x1="30" y1="540" x2="670" y2="540" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="545" font-family="Arial, sans-serif" font-size="13">E7 Regenerative Energy</text>
-<circle cx="280" cy="540" r="8" fill="#9370DB"/>
+<circle class="hub" cx="280" cy="540" r="8" fill="#9370DB"/>
 <text x="320" y="545" font-family="Arial, sans-serif" font-size="13" font-weight="bold">FERTILITY</text>
-<text x="450" y="540" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#9370DB">Germinal</text>
-<text x="450" y="555" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#9370DB">Cosmos</text>
+<text x="450" y="540" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#9370DB" text-decoration="underline">Germinal</text>
+<text x="450" y="555" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#9370DB" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="540" r="5" fill="#816270"/>
 <line x1="280" y1="540" x2="190" y2="440" stroke="#9370DB" stroke-width="1"/>
 <line x1="280" y1="540" x2="190" y2="490" stroke="#9370DB" stroke-width="1"/>
 <line x1="280" y1="540" x2="190" y2="540" stroke="#9370DB" stroke-width="1"/>
 <line x1="280" y1="540" x2="190" y2="590" stroke="#9370DB" stroke-width="1"/>
 <line x1="280" y1="540" x2="190" y2="640" stroke="#9370DB" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Phytogenic Cosmos (E8) -->
+<a href="/eight-cosmoses/phytogenic-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="570" width="400" height="40" fill="#32CD32" fill-opacity="0"/>
 <line x1="30" y1="590" x2="670" y2="590" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="595" font-family="Arial, sans-serif" font-size="13">E8 Constructive Energy</text>
-<circle cx="280" cy="590" r="8" fill="#32CD32"/>
+<circle class="hub" cx="280" cy="590" r="8" fill="#32CD32"/>
 <text x="320" y="595" font-family="Arial, sans-serif" font-size="13" font-weight="bold">VITALITY</text>
-<text x="450" y="590" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#32CD32">Phytogenic</text>
-<text x="450" y="605" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#32CD32">Cosmos</text>
+<text x="450" y="590" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#32CD32" text-decoration="underline">Phytogenic</text>
+<text x="450" y="605" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#32CD32" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="590" r="5" fill="#876A3D"/>
 <line x1="280" y1="590" x2="190" y2="490" stroke="#32CD32" stroke-width="1"/>
 <line x1="280" y1="590" x2="190" y2="540" stroke="#32CD32" stroke-width="1"/>
 <line x1="280" y1="590" x2="190" y2="590" stroke="#32CD32" stroke-width="1"/>
 <line x1="280" y1="590" x2="190" y2="640" stroke="#32CD32" stroke-width="1"/>
 <line x1="280" y1="590" x2="190" y2="690" stroke="#32CD32" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Sustaining Cosmos (E9) -->
+<a href="/eight-cosmoses/sustaining-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="620" width="400" height="40" fill="#FF6347" fill-opacity="0"/>
 <line x1="30" y1="640" x2="670" y2="640" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="645" font-family="Arial, sans-serif" font-size="13">E9 Adaptive Energy</text>
-<circle cx="280" cy="640" r="8" fill="#FF6347"/>
+<circle class="hub" cx="280" cy="640" r="8" fill="#FF6347"/>
 <text x="320" y="645" font-family="Arial, sans-serif" font-size="13" font-weight="bold">COMPLEXITY</text>
-<text x="450" y="640" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF6347">Sustaining</text>
-<text x="450" y="655" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF6347">Cosmos</text>
+<text x="450" y="640" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF6347" text-decoration="underline">Sustaining</text>
+<text x="450" y="655" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF6347" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="640" r="5" fill="#FF7723"/>
 <line x1="280" y1="640" x2="190" y2="540" stroke="#FF6347" stroke-width="1"/>
 <line x1="280" y1="640" x2="190" y2="590" stroke="#FF6347" stroke-width="1"/>
 <line x1="280" y1="640" x2="190" y2="640" stroke="#FF6347" stroke-width="1"/>
 <line x1="280" y1="640" x2="190" y2="690" stroke="#FF6347" stroke-width="1"/>
 <line x1="280" y1="640" x2="190" y2="740" stroke="#FF6347" stroke-width="1"/>
+</g>
+</a>
+
+<!-- Crystalline Cosmos (E10) -->
+<a href="/eight-cosmoses/crystalline-cosmos/">
+<g class="cosmos-pentad">
+<rect x="270" y="670" width="400" height="40" fill="#FF8C00" fill-opacity="0"/>
 <line x1="30" y1="690" x2="670" y2="690" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="695" font-family="Arial, sans-serif" font-size="13">E10 Cohesive Energy</text>
-<circle cx="280" cy="690" r="8" fill="#FF8C00"/>
+<circle class="hub" cx="280" cy="690" r="8" fill="#FF8C00"/>
 <text x="320" y="695" font-family="Arial, sans-serif" font-size="13" font-weight="bold">MATERIALITY</text>
-<text x="450" y="690" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF8C00">Crystalline</text>
-<text x="450" y="705" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF8C00">Cosmos</text>
+<text x="450" y="690" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF8C00" text-decoration="underline">Crystalline</text>
+<text x="450" y="705" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#FF8C00" text-decoration="underline">Cosmos</text>
 <circle cx="190" cy="690" r="5" fill="#FF8C00"/>
 <line x1="280" y1="690" x2="190" y2="590" stroke="#FF8C00" stroke-width="1"/>
 <line x1="280" y1="690" x2="190" y2="640" stroke="#FF8C00" stroke-width="1"/>
 <line x1="280" y1="690" x2="190" y2="690" stroke="#FF8C00" stroke-width="1"/>
 <line x1="280" y1="690" x2="190" y2="740" stroke="#FF8C00" stroke-width="1"/>
 <line x1="280" y1="690" x2="190" y2="790" stroke="#FF8C00" stroke-width="1"/>
+</g>
+</a>
+
 <line x1="30" y1="740" x2="670" y2="740" stroke="#ccc" stroke-width="1"/>
 <text x="30" y="745" font-family="Arial, sans-serif" font-size="13">E11 Patterning Energy</text>
 <circle cx="190" cy="740" r="5" fill="#FF8C00"/>


### PR DESCRIPTION
## Summary
- Create new eight-cosmoses section with 8 interactive pentad sub-pages
- Make each cosmos clickable from the main eight-cosmoses diagram
- Pentads use arrowhead K5 complete graph layout showing all energy interconnections
- Central energy is primary cosmos nucleus with 4 supporting energies arranged symmetrically
- Ready for DU2 text content to be added to each pentad

## Test Plan
- [ ] View /meta/eight-cosmoses/ page and verify all 8 cosmos names are clickable
- [ ] Click each cosmos to verify it opens the correct pentad page
- [ ] Verify pentad diagram displays correctly with all 10 edges and 5 nodes
- [ ] Verify colors match the energy level scheme

🤖 Generated with Claude Code